### PR TITLE
Create output directories

### DIFF
--- a/news/47.bugfix.md
+++ b/news/47.bugfix.md
@@ -1,0 +1,1 @@
+Create output parent directories if they don't exist.

--- a/src/pdm_packer/command.py
+++ b/src/pdm_packer/command.py
@@ -80,6 +80,7 @@ class PackCommand(BaseCommand):
             suffix = ".pyz" if not options.exe else ".exe" if os.name == "nt" else ""
             output = Path(name + suffix)
 
+        output.parent.mkdir(parents=True, exist_ok=True)
         output.write_bytes(bytes)
         if options.exe:
             output.chmod(output.stat().st_mode | stat.S_IEXEC)

--- a/tests/test_packer.py
+++ b/tests/test_packer.py
@@ -150,3 +150,11 @@ def test_pack_create_exe_file(example_project, invoke, tmp_path):
     assert output.stat().st_mode & stat.S_IEXEC
 
     subprocess.check_call([str(output)])
+
+
+def test_create_output_file_path(example_project, invoke, tmp_path):
+    output = tmp_path / "not_existing_directory" / "foo.pyz"
+    invoke(["pack", "-m", "app:main", "-o", str(output)], obj=example_project)
+
+    assert output.exists()
+    subprocess.check_call([sys.executable, str(output)])


### PR DESCRIPTION
Currently, `pdm-packer` fails when a parent directory of the output file does not exist. This is fixed with this PR.